### PR TITLE
Remove pinned Docker image on the Docker Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.7.1](https://github.com/timoa/app-stores-prometheus-exporter/compare/v0.7.0...v0.7.1) (2022-04-13)
+
+
+### Bug Fixes
+
+* **docker:** updating Docker description with API doesn't work with MFA ([c5e538f](https://github.com/timoa/app-stores-prometheus-exporter/commit/c5e538f1f2494f50230386634822fe2a34c26836))
+
 # [0.7.0](https://github.com/timoa/app-stores-prometheus-exporter/compare/v0.6.1...v0.7.0) (2022-04-12)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   api:
-    image: timoa/app-stores-prometheus-exporter:latest@sha256:e547e2122b6f0a3316adba40c4b38763a3984e63e0c07cb0ce03265d316c8182
+    image: timoa/app-stores-prometheus-exporter:latest
     environment:
       - NODE_ENV=production
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   api:
-    image: timoa/app-stores-prometheus-exporter:latest@sha256:385d7513c04ebb147de1ff1ea5676d79fd62efb46f0c2c358150ccdf10a076c4
+    image: timoa/app-stores-prometheus-exporter:latest@sha256:e547e2122b6f0a3316adba40c4b38763a3984e63e0c07cb0ce03265d316c8182
     environment:
       - NODE_ENV=production
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-stores-prometheus-exporter",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "app-stores-prometheus-exporter",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "os": [
         "linux",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-stores-prometheus-exporter",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Prometheus exporter that exports metrics (score, ratings, reviews, app version, etc.) from Apple App Store and Google Play (and more in the future).",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Since the image hash is updated after a release with Renovate on the `develop` branch, the Docker Compose use the previous version and not the latest.