### PR TITLE
Clear the cache before returning

### DIFF
--- a/src/exporter.js
+++ b/src/exporter.js
@@ -48,6 +48,7 @@ server.on('request', (req, res) => {
   if (req.method === 'GET' && req.url === '/metrics') {
     getPayload()
       .then((payload) => {
+        prometheus.init();
         res.setHeader('Content-Type', prometheus.getContentType);
         res.end(payload);
       })

--- a/src/lib/prometheus.js
+++ b/src/lib/prometheus.js
@@ -216,7 +216,9 @@ function init() {
   config.stores.forEach((store) => {
     // Metrics enabled only
     Object.keys(config.metrics).forEach((metric) => {
-      if (!gauges[metric] && getEnabledMetrics(store).includes(metric)) {
+      if (gauges[metric]) {
+        gauges[metric].reset();
+      } else if (getEnabledMetrics(store).includes(metric)) {
         // Create gauge
         gauges[metric] = createGauge({
           name: metrics[metric].name,


### PR DESCRIPTION
Clear the cache before returning to avoid old versions of scores appearing in the output and display as horizontal lines in Prometheus.
![image](https://github.com/timoa/app-stores-prometheus-exporter/assets/4949937/0af5c2d3-64c9-46ce-8918-4559d8b690ab)
