### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "darwin"
   ],
   "devDependencies": {
-    "acorn": "8.10.0",
     "acorn-jsx": "5.3.2",
     "chai": "4.3.8",
     "chai-as-promised": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "darwin"
   ],
   "devDependencies": {
-    "acorn-jsx": "5.3.2",
     "chai": "4.3.8",
     "chai-as-promised": "7.1.1",
     "chai-http": "4.4.0",


### PR DESCRIPTION
Hello,

I noticed that dependencies `acorn` and` acorn-jsx ` declared in the `package.json` file are unused in the source files of the project. Removing these unused dependencies has an impact on the number of CI build minutes that are consumed during CI due to bumpings of unused dependencies by bots. In fact, I found 11 commits, bumping versions of these unused dependencies, recently made by the renovate bot, and those commits consume over 88 minutes of build time. Thus, removing the unused dependencies (including the ones I suggested) would save a substantial amount of CI build time. 

On the other hand, removing unused dependencies may reduce the number of pull requests needed to be reviewed by developers for such cases.